### PR TITLE
Implement threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Based on the original Python script from https://project.ibroadcast.com
  - fixed parsing directories with special characters in their names
  - added progress bar
  - added local MD5 cache to skip hash recalculation every time
- - added command line arguments (directory, confirmation skip, verbose and silent modes)
+ - added command line arguments (directory, confirmation skip, parallel uploads, verbose and silent modes)

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -399,7 +399,7 @@ if __name__ == '__main__':
     parser.add_argument('directory', type=str, nargs='?', help='Use this directory instead of the current one')
     parser.add_argument('-n', '--no-cache', action='store_true', help='Do not use local MD5 cache')
     parser.add_argument('-v', '--verbose', action='store_true', help='Be verbose')
-    parser.add_argument('-p', '--parallel-uploads', type=int, nargs='?', const=1, default=1, choices=range(1,17), metavar="1-16", help='Number of parallel uploads. Disabled by default.')
+    parser.add_argument('-p', '--parallel-uploads', type=int, nargs='?', const=3, default=3, choices=range(0,6), metavar="0-6", help='Number of parallel uploads, 3 by default.')
     parser.add_argument('-s', '--silent', action='store_true', help='Be silent')
     parser.add_argument('-y', '--skip-confirmation', action='store_true', help='Skip confirmation dialogue')
 

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -28,7 +28,7 @@ class Uploader(object):
     Class for uploading content to iBroadcast.
     """
 
-    VERSION = '0.4'
+    VERSION = '0.5'
     CLIENT = 'python 3 uploader script'
     DEVICE_NAME = 'python 3 uploader script'
     USER_AGENT = 'ibroadcast-uploader/' + VERSION

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -338,7 +338,7 @@ class Uploader(object):
             file_list = self.files[fileIndex]
 
         for filename in file_list:
-            if threaded:
+            if (threaded and not self.be_silent):
                 print('Uploading:', filename)
 
             # Get an md5 of the file contents and compare it to whats up


### PR DESCRIPTION
Disabled by default. Allows the user to specify the amount of parallel uploads through a parameter `-p`, with values ranging from 1 to 16 (iBroadcast's limit hasn't been tested, we may need to lower the maximum value).
The progress bar is not working for multithreaded uploads.
Testing on my network (50Mbps upload) has shown an improvement of 30 seconds when uploading a folder containing 500MiB of files. Improvements could be bigger on faster networks and/or with more threads.
**4 parallel uploads:**
![image](https://user-images.githubusercontent.com/61394886/192755779-93fe05f4-9d6f-4c01-9ce0-5e87ebbd342f.png)
**Default upload (single threaded):**
![image](https://user-images.githubusercontent.com/61394886/192755796-9178547f-0cab-4c62-a8ea-3b355d6a12b5.png)

I'm unsure about the user interface, should we print the filenames by default, regardless of the verbose parameter? Should we enable threading by default with a sane value, like ```-p 4```?
