### PR TITLE
Playlist, tag and reupload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # iBroadcast Uploader
 Based on the original Python script from https://project.ibroadcast.com
 
-## What's new
+## What's new in 0.6
+ - The accepted range specified for '--parallel-uploads' was wrong. Fixed to accept numbers from 1 to 6. Default kept at 3.
+ - Added the "--playlist", "--tag", and "--reupload" command line arguments
+
+## What's new in 0.5
  - fixed parsing directories with special characters in their names
  - added progress bar
  - added local MD5 cache to skip hash recalculation every time

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -34,7 +34,7 @@ class Uploader(object):
     USER_AGENT = 'ibroadcast-uploader/' + VERSION
 
 
-    def __init__(self, login_token, directory, no_cache, verbose, silent, skip_confirmation, parallel_uploads, reupload, tag, playlist):
+    def __init__(self, login_token, directory, no_cache, verbose, silent, skip_confirmation, parallel_uploads, playlist, tag, reupload):
         if verbose:
             sys.tracebacklimit = 1000
 
@@ -311,9 +311,7 @@ class Uploader(object):
                 file_md5 = self.calcmd5(filename)
                 self.md5_int[filename] = file_md5
 
-            if file_md5 in self.md5_ext:
-                if self.reupload is True:
-                    continue
+            if file_md5 in self.md5_ext and self.reupload is False:
                 self.skipped_files.append(filename)
                 if not self.be_silent and self.be_verbose:
                     if not print_filename_again:

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -28,13 +28,13 @@ class Uploader(object):
     Class for uploading content to iBroadcast.
     """
 
-    VERSION = '0.5'
+    VERSION = '0.6'
     CLIENT = 'python 3 uploader script'
     DEVICE_NAME = 'python 3 uploader script'
     USER_AGENT = 'ibroadcast-uploader/' + VERSION
 
 
-    def __init__(self, login_token, directory, no_cache, verbose, silent, skip_confirmation, parallel_uploads):
+    def __init__(self, login_token, directory, no_cache, verbose, silent, skip_confirmation, parallel_uploads, reupload, tag, playlist):
         if verbose:
             sys.tracebacklimit = 1000
 
@@ -58,6 +58,9 @@ class Uploader(object):
         self.md5_int_path = None
         self.md5_int = None
         self.md5_ext = None
+        self.reupload = reupload
+        self.tag = tag
+        self.playlist = playlist
 
     def process(self):
         try:
@@ -309,6 +312,8 @@ class Uploader(object):
                 self.md5_int[filename] = file_md5
 
             if file_md5 in self.md5_ext:
+                if self.reupload is True:
+                    continue
                 self.skipped_files.append(filename)
                 if not self.be_silent and self.be_verbose:
                     if not print_filename_again:
@@ -381,6 +386,8 @@ class Uploader(object):
             'token': self.token,
             'file_path' : filename,
             'method': self.CLIENT,
+            'tag-name': self.tag,
+            'playlist-name': self.playlist
         }
 
         response = requests.post(
@@ -411,8 +418,11 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--parallel-uploads', type=int, nargs='?', const=3, default=3, choices=range(1,7), metavar='1-6', help='Number of parallel uploads, 3 by default.')
     parser.add_argument('-s', '--silent', action='store_true', help='Be silent')
     parser.add_argument('-y', '--skip-confirmation', action='store_true', help='Skip confirmation dialogue')
+    parser.add_argument('-l', '--playlist', type=str, help='Add uploaded files to this playlist')
+    parser.add_argument('-t', '--tag', type=str, help='Apply this tag to the uploaded files')
+    parser.add_argument('-r', '--reupload', action='store_true', help='Force re-uploading files')
 
     args = parser.parse_args()
-    uploader = Uploader(args.login_token,args.directory,args.no_cache,args.verbose,args.silent,args.skip_confirmation,args.parallel_uploads)
+    uploader = Uploader(args.login_token,args.directory,args.no_cache,args.verbose,args.silent,args.skip_confirmation,args.parallel_uploads, args.playlist, args.tag, args.reupload)
 
     uploader.process()

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -346,9 +346,6 @@ class Uploader(object):
 
     def prepare_upload(self):
         threads = args.parallel_uploads
-        if (threads == 0):
-            threads = 1
-
         total_files = len(self.files)
         # Remove already uploaded files from the list of files
         self.check_md5()
@@ -411,7 +408,7 @@ if __name__ == '__main__':
     parser.add_argument('directory', type=str, nargs='?', help='Use this directory instead of the current one')
     parser.add_argument('-n', '--no-cache', action='store_true', help='Do not use local MD5 cache')
     parser.add_argument('-v', '--verbose', action='store_true', help='Be verbose')
-    parser.add_argument('-p', '--parallel-uploads', type=int, nargs='?', const=3, default=3, choices=range(0,6), metavar='0-6', help='Number of parallel uploads, 3 by default.')
+    parser.add_argument('-p', '--parallel-uploads', type=int, nargs='?', const=3, default=3, choices=range(1,7), metavar='1-6', help='Number of parallel uploads, 3 by default.')
     parser.add_argument('-s', '--silent', action='store_true', help='Be silent')
     parser.add_argument('-y', '--skip-confirmation', action='store_true', help='Skip confirmation dialogue')
 


### PR DESCRIPTION
Added the "--playlist", "--tag", and "--reupload" command line arguments

+ small fix: The accepted range specified for '--parallel-uploads' was wrong. For me it makes no sense to accept 0 as a parameter, and 6 was rejected completely. Fixed to accept numbers from 1 to 6. Default kept at 3. 