### PR TITLE
Parallel uploads fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # iBroadcast Uploader
 Based on the original Python script from https://project.ibroadcast.com
 
+## What's new in 0.6.1
+ - Fix bug in reference to parallel_uploads argument 
+
 ## What's new in 0.6
  - The accepted range specified for '--parallel-uploads' was wrong. Fixed to accept numbers from 1 to 6. Default kept at 3.
  - Added the "--playlist", "--tag", and "--reupload" command line arguments

--- a/ibroadcast-uploader.py
+++ b/ibroadcast-uploader.py
@@ -28,7 +28,7 @@ class Uploader(object):
     Class for uploading content to iBroadcast.
     """
 
-    VERSION = '0.6'
+    VERSION = '0.6.1'
     CLIENT = 'python 3 uploader script'
     DEVICE_NAME = 'python 3 uploader script'
     USER_AGENT = 'ibroadcast-uploader/' + VERSION
@@ -61,6 +61,7 @@ class Uploader(object):
         self.reupload = reupload
         self.tag = tag
         self.playlist = playlist
+        self.parallel_uploads = parallel_uploads
 
     def process(self):
         try:
@@ -348,7 +349,7 @@ class Uploader(object):
             print("\n", flush=True, file=out)
 
     def prepare_upload(self):
-        threads = args.parallel_uploads
+        threads = self.parallel_uploads
         total_files = len(self.files)
         # Remove already uploaded files from the list of files
         self.check_md5()


### PR DESCRIPTION
- Set parallel_uploads instance with arg value passed into constructor function
- Update prepare_upload function to reference parallel_uploads instance variable since args object is out of scope